### PR TITLE
fix: update goreleaser config for v2 compatibility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,30 +13,17 @@ archives:
         format: zip
     builds:
       - skillguard
-    files:
-      - README.md
-      - LICENSE
-      - CONTRIBUTING.md
 
 checksum:
   name_template: 'checksums.txt'
 
-snapshot:
-  name_template: "{{ .Version }}-next"
-
 changelog:
-  skip: false
   filters:
     exclude:
       - '^docs:'
       - '^chore:'
       - '^test:'
 
-github:
-  owner: OSSAfrica
-  name: skillguard
-
-# Build configuration
 builds:
   - id: skillguard
     binary: skillguard
@@ -54,7 +41,6 @@ builds:
     env:
       - CGO_ENABLED=0
 
-# Docker configuration
 dockers:
   - image_templates:
       - 'OSSAfrica/skillguard:{{ .Version }}'
@@ -62,23 +48,6 @@ dockers:
     goos: linux
     goarch: amd64
     dockerfile: Dockerfile
-    build_flag_templates:
-      - --label=org.opencontainers.image.title=SkillGuard
-      - --label=org.opencontainers.image.description=Security scanner for AI agent skills
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.source=https://github.com/OSSAfrica/skillguard
 
-# Release configuration
 release:
-  github:
-    owner: OSSAfrica
-    name: skillguard
-  name_template: '{{ .Tag }}'
-  body_template: |
-    ## Changes in {{ .Tag }}
-
-    {{ range .Commits }}
-    - {{ .Message }}
-    {{ end }}
-
-    **Full Changelog**: https://github.com/OSSAfrica/skillguard/compare/{{ .PreviousTag }}...{{ .Tag }}
+  draft: false


### PR DESCRIPTION
- Remove deprecated fields (changelog.skip, github top-level, body_template)
- Add version: 2 to config
- Simplify docker and release configuration