### PR TITLE
fix: fetch tags before goreleaser runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags origin
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
- Add fetch-depth: 0 to checkout step
- Add git fetch --tags origin to ensure goreleaser finds the version tag