### PR TITLE
fix: update goreleaser config to use v2 syntax

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,10 +7,9 @@ project_name: skillguard
 
 archives:
   - id: default
-    format: tar.gz
-    format_overrides:
-      - goos: windows
-        format: zip
+    formats:
+      - tar.gz
+      - zip
     builds:
       - skillguard
 
@@ -41,13 +40,19 @@ builds:
     env:
       - CGO_ENABLED=0
 
-dockers:
-  - image_templates:
-      - 'OSSAfrica/skillguard:{{ .Version }}'
-      - 'OSSAfrica/skillguard:latest'
-    goos: linux
-    goarch: amd64
+docker_manifests:
+  - image_template: 'OSSAfrica/skillguard:{{ .Version }}'
     dockerfile: Dockerfile
+    build_flag_templates:
+      - --label=org.opencontainers.image.title=SkillGuard
+      - --label=org.opencontainers.image.description=Security scanner for AI agent skills
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.source=https://github.com/OSSAfrica/skillguard
+  - image_template: 'OSSAfrica/skillguard:latest'
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - --label=org.opencontainers.image.title=SkillGuard
+      - --label=org.opencontainers.image.description=Security scanner for AI agent skills
 
 release:
   draft: false


### PR DESCRIPTION
- Replace archives.format with archives.formats
- Replace archives.format_overrides with formats array
- Replace dockers with docker_manifests for v2 compatibility
- Remove deprecated builds from archives (use top-level)