### PR TITLE
fix: add GHCR login and pull steps before signing and SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
   sign:
-    needs: [ release, docker ]
+    needs: [ versioning, docker ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -154,6 +154,18 @@ jobs:
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image to sign
+        run: |
+          echo "${{ needs.versioning.outputs.version }}" > version.txt
+          docker pull ghcr.io/${{ github.repository }}:${{ needs.versioning.outputs.version }} || docker pull ghcr.io/${{ github.repository }}:latest
 
       - name: Sign Docker image
         run: |
@@ -164,7 +176,7 @@ jobs:
           cosign verify ghcr.io/${{ github.repository }}:${{ needs.versioning.outputs.version }}
 
   sbom:
-    needs: [ docker ]
+    needs: [ versioning, docker ]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -185,10 +197,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull image for SBOM
+        run: |
+          docker pull ghcr.io/${{ github.repository }}:${{ needs.versioning.outputs.version }} || docker pull ghcr.io/${{ github.repository }}:latest
+
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ghcr.io/${{ github.repository }}:latest
+          image: ghcr.io/${{ github.repository }}:${{ needs.versioning.outputs.version }}
           output-file: skillguard-sbom.spdx
 
       - name: Upload SBOM to Release


### PR DESCRIPTION
- Add GHCR login step to sign job before pulling
- Add docker pull step to both sign and sbom jobs
- Use explicit version tag instead of latest for reproducibility
- Fix dependency ordering (needs versioning, docker)