### PR TITLE
fix: convert repository name to lowercase for GHCR compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,11 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Set lowercase repo name
+        run: |
+          echo "REPO=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "VERSION=${{ needs.versioning.outputs.version }}" >> $GITHUB_ENV
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
@@ -164,16 +169,15 @@ jobs:
 
       - name: Pull image to sign
         run: |
-          echo "${{ needs.versioning.outputs.version }}" > version.txt
-          docker pull ghcr.io/${{ github.repository }}:${{ needs.versioning.outputs.version }} || docker pull ghcr.io/${{ github.repository }}:latest
+          docker pull ghcr.io/${{ env.REPO }}:${{ env.VERSION }} || docker pull ghcr.io/${{ env.REPO }}:latest
 
       - name: Sign Docker image
         run: |
-          cosign sign --yes ghcr.io/${{ github.repository }}:${{ needs.versioning.outputs.version }}
+          cosign sign --yes ghcr.io/${{ env.REPO }}:${{ env.VERSION }}
 
       - name: Verify signatures
         run: |
-          cosign verify ghcr.io/${{ github.repository }}:${{ needs.versioning.outputs.version }}
+          cosign verify ghcr.io/${{ env.REPO }}:${{ env.VERSION }}
 
   sbom:
     needs: [ versioning, docker ]
@@ -182,6 +186,11 @@ jobs:
       contents: read
       packages: read
     steps:
+      - name: Set lowercase repo name
+        run: |
+          echo "REPO=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "VERSION=${{ needs.versioning.outputs.version }}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -199,12 +208,12 @@ jobs:
 
       - name: Pull image for SBOM
         run: |
-          docker pull ghcr.io/${{ github.repository }}:${{ needs.versioning.outputs.version }} || docker pull ghcr.io/${{ github.repository }}:latest
+          docker pull ghcr.io/${{ env.REPO }}:${{ env.VERSION }} || docker pull ghcr.io/${{ env.REPO }}:latest
 
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ghcr.io/${{ github.repository }}:${{ needs.versioning.outputs.version }}
+          image: ghcr.io/${{ env.REPO }}:${{ env.VERSION }}
           output-file: skillguard-sbom.spdx
 
       - name: Upload SBOM to Release


### PR DESCRIPTION
- Add step to set lowercase REPO and VERSION env vars in sign and sbom jobs
- Use ${{ env.REPO }} and ${{ env.VERSION }} in all docker/cosign/sbom commands
- Fixes 'invalid reference format: repository name must be lowercase' errors