### PR TITLE
chore(ci): update dependencies and improve SBOM workflow logic

### DIFF
--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -36,5 +36,5 @@ jobs:
         uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
         with:
           image: "localbuild/testimage:latest"
-          artifact-name: image.spdx.json
+          artifact-name: image-spdx
           dependency-snapshot: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           cosign verify ghcr.io/${{ env.REPO }}:latest
 
   sbom:
-    needs: [ versioning, docker ]
+    needs: [ versioning, release, docker ]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -220,8 +220,8 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: skillguard-sbom.spdx
-          name: skillguard-${{ needs.versioning.outputs.version }}-sbom.spdx
-          release_name: skillguard-${{ needs.versioning.outputs.version }}
+          tag_name: ${{ needs.versioning.outputs.version }}
+          overwrite: true
 
   notify:
     needs: [ versioning, release, docker, sign, sbom ]


### PR DESCRIPTION
- Add `release` job as a dependency for `sbom` in release workflow.
- Use `overwrite: true` and `tag_name` for SBOM release asset upload.
- Update artifact name in Anchore Syft workflow for consistency.