### PR TITLE
fix(ci): export GH_TOKEN for gh CLI in SBOM upload step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,7 @@ jobs:
 
       - name: Upload SBOM to Release
         run: |
+          export GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           VERSION="${{ needs.versioning.outputs.version }}"
           GH_ASSET="skillguard-${VERSION}-sbom.spdx"
           mv skillguard-sbom.spdx "$GH_ASSET"


### PR DESCRIPTION
gh release view requires GH_TOKEN environment variable, not just secret in header