### PR TITLE
fix(config): handle missing config file and default paths gracefully

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -78,15 +79,32 @@ func loadConfig() *Config {
 	v := viper.New()
 	v.SetConfigName("skillguard")
 	v.SetConfigType("yaml")
-	v.AddConfigPath("$HOME")
+
+	home := os.Getenv("HOME")
+	v.AddConfigPath(home)
 	v.AddConfigPath(".")
 
-	v.SetDefault("default_path", "~/.agents/skills")
+	v.SetDefault("default_path", home+"/.agents/skills")
 	v.SetDefault("threshold", 70)
 
-	v.ReadInConfig()
+	err := v.ReadInConfig()
+	if err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			if writeErr := v.SafeWriteConfig(); writeErr != nil {
+				fmt.Printf("Failed to create default config: %v\n", writeErr)
+			} else {
+				fmt.Println("No config file found. Created default config at ~/.skillguard.yaml")
+			}
+		}
+	}
 
-	return &Config{viper: v}
+	cfg := &Config{viper: v}
+
+	if cfg.DefaultPath == "" {
+		cfg.DefaultPath = home + "/.agents/skills"
+	}
+
+	return cfg
 }
 
 func (c *Config) Save() error {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -24,15 +24,14 @@ var (
 )
 
 var scanCmd = &cobra.Command{
-	Use:   "scan",
+	Use:   "scan [path]",
 	Short: "Scan AI skill definitions for security risks",
 	Long:  `SkillGuard analyzes Markdown-based skill definitions for security vulnerabilities, dangerous permissions, and supply chain risks.`,
 	RunE:  runScan,
 }
 
 func init() {
-	cfg := loadConfig()
-	scanCmd.Flags().StringVarP(&scanPath, "path", "p", cfg.DefaultPath,
+	scanCmd.Flags().StringVarP(&scanPath, "path", "p", "",
 		"Path to scan (file, directory, or comma-separated paths)")
 	scanCmd.Flags().IntVarP(&threshold, "threshold", "t", 70,
 		"Minimum score to pass (0-100)")
@@ -48,7 +47,15 @@ func init() {
 
 func runScan(cmd *cobra.Command, args []string) error {
 	cfg := loadConfig()
-	paths := parsePaths(scanPath, cfg.DefaultPath)
+
+	var paths []string
+	if len(args) > 0 {
+		paths = args
+	} else if scanPath != "" {
+		paths = []string{scanPath}
+	} else {
+		paths = []string{cfg.DefaultPath}
+	}
 
 	var allFiles []string
 	for _, p := range paths {


### PR DESCRIPTION
- Add logic to create a default config file if none exists.
- Improve handling of default `HOME`-based paths for configuration and scans.
- Allow `scan` command to accept paths via arguments or flags.