### PR TITLE
Add support for analyzing reference files and improve scan output

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -262,7 +262,7 @@ func printSkillResult(r *model.AnalysisResult, verbose bool) {
 		for _, f := range r.Findings {
 			severityIcon := getSeverityIcon(f.Severity)
 			sevColor := getSeverityColor(f.Severity)
-			_, err2 := sevColor.Printf("    %s [%s] %s", severityIcon, f.Severity, f.Description)
+			_, err2 := sevColor.Printf("    %s %s", severityIcon, f.Description)
 			if err2 != nil {
 				return
 			}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -57,7 +57,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 		paths = []string{cfg.DefaultPath}
 	}
 
-	var allFiles []string
+	var allFiles []parser.FoundFile
 	for _, p := range paths {
 		expandedPath := expandPath(p)
 		files, err := parser.FindSkillFiles(expandedPath)
@@ -81,17 +81,28 @@ func runScan(cmd *cobra.Command, args []string) error {
 		Results:   []model.AnalysisResult{},
 	}
 
-	for _, file := range allFiles {
-		metadata, body, err := parser.ParseSkillFile(file)
-		if err != nil {
-			if !quietMode {
-				color.Red("Error parsing %s: %v", file, err)
+	for _, f := range allFiles {
+		if f.FileType == parser.FileTypeReference {
+			body, err := parser.ExtractBodyOnly(f.Path)
+			if err != nil {
+				if !quietMode {
+					color.Red("Error reading %s: %v", f.Path, err)
+				}
+				continue
 			}
-			continue
+			result := scorer.AnalyzeReference(f.Path, body)
+			report.Results = append(report.Results, *result)
+		} else {
+			metadata, body, err := parser.ParseSkillFile(f.Path)
+			if err != nil {
+				if !quietMode {
+					color.Red("Error parsing %s: %v", f.Path, err)
+				}
+				continue
+			}
+			result := scorer.Analyze(f.Path, metadata, body)
+			report.Results = append(report.Results, *result)
 		}
-
-		result := scorer.Analyze(file, metadata, body)
-		report.Results = append(report.Results, *result)
 	}
 
 	report.TotalSkills = len(report.Results)
@@ -154,9 +165,9 @@ func printColoredReport(report *model.ScanReport) {
 
 	fmt.Printf("Scanned: %d skills | Threshold: %d | ", report.TotalSkills, report.Threshold)
 	if report.Failed == 0 {
-		color.Green("PASSED ✓")
+		color.Green("PASSED")
 	} else {
-		color.Red("FAILED ✗")
+		color.Red("FAILED")
 	}
 	fmt.Println()
 	fmt.Println(strings.Repeat("─", 70))
@@ -170,10 +181,15 @@ func printColoredReport(report *model.ScanReport) {
 }
 
 func printSkillResult(r *model.AnalysisResult, verbose bool) {
+	name := r.SkillName
+	if r.IsReference {
+		name = "[Reference] " + name
+	}
+
 	if r.Passed {
-		color.Green("✓ %s", r.SkillName)
+		color.Green("[PASS] %s", name)
 	} else {
-		color.Red("✗ %s", r.SkillName)
+		color.Red("[FAIL] %s", name)
 	}
 
 	scoreColor := getScoreColor(r.OverallScore)
@@ -222,13 +238,13 @@ func printSkillResult(r *model.AnalysisResult, verbose bool) {
 			}
 			fmt.Printf("    %s:\n", cs.Category)
 			for _, f := range cs.Breakdown {
-				checkIcon := "✓"
+				checkIcon := "OK"
 				checkColor := color.New(color.FgGreen)
 				if f.Deduction > 0 {
-					checkIcon = "✗"
+					checkIcon = "FAIL"
 					checkColor = getSeverityColor(f.Severity)
 				}
-				_, err := checkColor.Printf("      %s %s", checkIcon, f.Description)
+				_, err := checkColor.Printf("      [%s] %s", checkIcon, f.Description)
 				if err != nil {
 					return
 				}
@@ -292,11 +308,11 @@ func getSeverityColor(sev model.Severity) *color.Color {
 func getSeverityIcon(sev model.Severity) string {
 	switch sev {
 	case model.SeverityHigh:
-		return "🔴"
+		return "[HIGH]"
 	case model.SeverityMedium:
-		return "🟡"
+		return "[MEDIUM]"
 	default:
-		return "🔵"
+		return "[LOW]"
 	}
 }
 

--- a/internal/analyzer/scorer.go
+++ b/internal/analyzer/scorer.go
@@ -184,6 +184,37 @@ func (s *Scorer) Analyze(path string, metadata *model.SkillMetadata, body string
 	return result
 }
 
+func (s *Scorer) AnalyzeReference(path string, body string) *model.AnalysisResult {
+	name := filepath.Base(path)
+	if ext := filepath.Ext(name); ext != "" {
+		name = strings.TrimSuffix(name, ext)
+	}
+
+	result := &model.AnalysisResult{
+		SkillName:      name,
+		FilePath:       path,
+		IsReference:    true,
+		Findings:       []model.Finding{},
+		CategoryScores: s.initCategoryScores(),
+	}
+
+	result.Findings = append(result.Findings, s.checkShellExecution(body)...)
+	result.Findings = append(result.Findings, s.checkFileAccess(body)...)
+	result.Findings = append(result.Findings, s.checkNetworkAccess(body)...)
+	result.Findings = append(result.Findings, s.checkCredentials(body)...)
+	result.Findings = append(result.Findings, s.checkObfuscatedCode(body)...)
+	result.Findings = append(result.Findings, s.checkHttpDependencies(body)...)
+	result.Findings = append(result.Findings, s.checkHiddenCharacters(body)...)
+
+	result.CategoryScores = s.calculateCategoryScores(result.Findings)
+
+	overallScore := s.calculateOverallScore(result.CategoryScores)
+	result.OverallScore = overallScore
+	result.Passed = overallScore >= s.threshold
+
+	return result
+}
+
 func (s *Scorer) initCategoryScores() []model.CategoryScore {
 	return []model.CategoryScore{
 		{Category: model.CatSupplyChain, Score: 100, Findings: 0},

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -75,6 +75,7 @@ type AnalysisResult struct {
 	FilePath       string          `json:"file_path"`
 	OverallScore   int             `json:"overall_score"`
 	Passed         bool            `json:"passed"`
+	IsReference    bool            `json:"is_reference"`
 	Findings       []Finding       `json:"findings"`
 	Metadata       SkillMetadata   `json:"metadata"`
 	CategoryScores []CategoryScore `json:"category_scores"`

--- a/internal/parser/markdown.go
+++ b/internal/parser/markdown.go
@@ -126,7 +126,7 @@ func ExtractBodyOnly(path string) (string, error) {
 		if err == ErrNoFrontmatter {
 			return string(content), nil
 		}
-		return "", err
+		return string(content), nil
 	}
 
 	if frontmatter != nil && body == "" {
@@ -170,19 +170,16 @@ func FindSkillFiles(path string) ([]FoundFile, error) {
 			if strings.HasSuffix(lowerName, ".md") {
 				content, readErr := os.ReadFile(p)
 				if readErr == nil {
+					isSkillFile := lowerName == "skill.md" || lowerName == "skills.md"
+
 					if strings.HasPrefix(strings.TrimSpace(string(content)), "---") {
-						isRef := strings.Contains(p, "/references/") || strings.Contains(p, "\\references\\")
 						fileType := FileTypeSkill
-						if isRef {
+						if !isSkillFile {
 							fileType = FileTypeReference
 						}
 						files = append(files, FoundFile{Path: p, FileType: fileType})
-					} else {
-						isRef := strings.Contains(p, "/references/") || strings.Contains(p, "\\references\\") ||
-							strings.Contains(p, "/templates/") || strings.Contains(p, "\\templates\\")
-						if isRef {
-							files = append(files, FoundFile{Path: p, FileType: FileTypeReference})
-						}
+					} else if !isSkillFile {
+						files = append(files, FoundFile{Path: p, FileType: FileTypeReference})
 					}
 				}
 			}

--- a/internal/parser/markdown.go
+++ b/internal/parser/markdown.go
@@ -115,7 +115,40 @@ func extractFrontmatter(content string) (*Frontmatter, string, error) {
 	return &fm, body, nil
 }
 
-func FindSkillFiles(path string) ([]string, error) {
+func ExtractBodyOnly(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	frontmatter, body, err := extractFrontmatter(string(content))
+	if err != nil {
+		if err == ErrNoFrontmatter {
+			return string(content), nil
+		}
+		return "", err
+	}
+
+	if frontmatter != nil && body == "" {
+		return "", fmt.Errorf("empty body in %s", path)
+	}
+
+	return body, nil
+}
+
+type FileType int
+
+const (
+	FileTypeSkill FileType = iota
+	FileTypeReference
+)
+
+type FoundFile struct {
+	Path     string
+	FileType FileType
+}
+
+func FindSkillFiles(path string) ([]FoundFile, error) {
 	path = strings.TrimSpace(path)
 
 	info, err := os.Stat(path)
@@ -123,7 +156,7 @@ func FindSkillFiles(path string) ([]string, error) {
 		return nil, fmt.Errorf("failed to access path: %w", err)
 	}
 
-	var files []string
+	var files []FoundFile
 
 	if info.IsDir() {
 		err = filepath.Walk(path, func(p string, fi os.FileInfo, err error) error {
@@ -131,17 +164,25 @@ func FindSkillFiles(path string) ([]string, error) {
 				return err
 			}
 			if fi.IsDir() {
-				if fi.Name() == "references" || fi.Name() == "templates" {
-					return filepath.SkipDir
-				}
 				return nil
 			}
 			lowerName := strings.ToLower(fi.Name())
 			if strings.HasSuffix(lowerName, ".md") {
-				if lowerName == "skill.md" || lowerName == "skills.md" {
-					content, readErr := os.ReadFile(p)
-					if readErr == nil && strings.HasPrefix(strings.TrimSpace(string(content)), "---") {
-						files = append(files, p)
+				content, readErr := os.ReadFile(p)
+				if readErr == nil {
+					if strings.HasPrefix(strings.TrimSpace(string(content)), "---") {
+						isRef := strings.Contains(p, "/references/") || strings.Contains(p, "\\references\\")
+						fileType := FileTypeSkill
+						if isRef {
+							fileType = FileTypeReference
+						}
+						files = append(files, FoundFile{Path: p, FileType: fileType})
+					} else {
+						isRef := strings.Contains(p, "/references/") || strings.Contains(p, "\\references\\") ||
+							strings.Contains(p, "/templates/") || strings.Contains(p, "\\templates\\")
+						if isRef {
+							files = append(files, FoundFile{Path: p, FileType: FileTypeReference})
+						}
 					}
 				}
 			}
@@ -153,8 +194,10 @@ func FindSkillFiles(path string) ([]string, error) {
 	} else {
 		if strings.HasSuffix(strings.ToLower(info.Name()), ".md") {
 			content, err := os.ReadFile(path)
-			if err == nil && strings.HasPrefix(strings.TrimSpace(string(content)), "---") {
-				files = []string{path}
+			if err == nil {
+				if strings.HasPrefix(strings.TrimSpace(string(content)), "---") {
+					files = []FoundFile{{Path: path, FileType: FileTypeSkill}}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds the ability for SkillGuard to scan reference documentation files within skill directories, not just the main `SKILL.md` files. This is critical for security scanning since attackers could hide malicious content in subdirectories.

### Changes:

1. **Reference File Detection** (`internal/parser/markdown.go`)
   - Scans ALL `.md` files in skill folders including subdirectories like `references/`, `templates/`, `rules/`, `scripts/`, `.hidden/`, etc.
   - Only `skill.md`/`skills.md` in the root are treated as skill files
   - All other `.md` files are treated as reference files

2. **Reference Analysis** (`internal/analyzer/scorer.go`)
   - New `AnalyzeReference()` method that runs security checks on reference documents
   - Handles files both with and without YAML frontmatter
   - Includes: shell execution, file access, network access, credentials, obfuscated code, HTTP dependencies

3. **Config Handling** (`cmd/config.go`)
   - Gracefully creates default config if none exists
   - Sets sensible defaults for first-time users

4. **Output Improvements** (`cmd/scan.go`)
   - Removed emoji duplication (`[HIGH] [high]` → `[HIGH]`)
   - Labels references with `[Reference]` prefix
   - Cleaner findings display

### Why This Matters:

Previously, scanning a skill like `tanstack-query` would only check `SKILL.md`. Now it also scans:
- `references/*.md`
- `rules/*.md`
- `templates/*.md`
- `.anything/*.md`
- Any `.md` file in any subdirectory

This prevents attackers from bypassing security checks by hiding malicious content in less obvious locations.