### PR TITLE
feat(release): add Homebrew tap configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,3 +40,13 @@ builds:
 
 release:
   draft: false
+
+brews:
+  - repository:
+      owner: OSSAfrica
+      name: homebrew-skillguard
+      token: "{{ .Env.GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/OSSAfrica/skillguard"
+    description: "Security scanner for AI skill definitions"
+    license: "MIT"


### PR DESCRIPTION
Add brews section to GoReleaser config to enable automatic publication of formula to homebrew-skillguard repository on GitHub releases.