### PR TITLE
fix(release): use goos/goarch filter for Homebrew tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -112,6 +112,7 @@ brews:
     homepage: "https://github.com/OSSAfrica/skillguard"
     description: "Security scanner for AI skill definitions"
     license: "MIT"
-    ids:
-      - skillguard-darwin-amd64
-      - skillguard-darwin-arm64
+    goos: darwin
+    goarch:
+      - amd64
+      - arm64


### PR DESCRIPTION
Use goos and goarch filters in brew section instead of ids to properly filter to macOS builds only.