### PR TITLE
feat(release): add Homebrew tap configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,51 +22,31 @@ changelog:
       - '^test:'
 
 builds:
-  - id: skillguard-darwin-amd64
+  - id: skillguard-darwin
     binary: skillguard
     main: ./main.go
     goos:
       - darwin
     goarch:
       - amd64
-    ldflags:
-      - -s -w
-      - -X skillguard/cmd.version={{ .Version }}
-    env:
-      - CGO_ENABLED=0
-
-  - id: skillguard-darwin-arm64
-    binary: skillguard
-    main: ./main.go
-    goos:
-      - darwin
-    goarch:
       - arm64
     ldflags:
       - -s -w
       - -X skillguard/cmd.version={{ .Version }}
     env:
       - CGO_ENABLED=0
+    archives:
+      - id: darwin-archive
+        formats:
+          - tar.gz
 
-  - id: skillguard-linux-amd64
+  - id: skillguard-linux
     binary: skillguard
     main: ./main.go
     goos:
       - linux
     goarch:
       - amd64
-    ldflags:
-      - -s -w
-      - -X skillguard/cmd.version={{ .Version }}
-    env:
-      - CGO_ENABLED=0
-
-  - id: skillguard-linux-arm64
-    binary: skillguard
-    main: ./main.go
-    goos:
-      - linux
-    goarch:
       - arm64
     ldflags:
       - -s -w
@@ -74,31 +54,24 @@ builds:
     env:
       - CGO_ENABLED=0
 
-  - id: skillguard-windows-amd64
+  - id: skillguard-windows
     binary: skillguard
     main: ./main.go
     goos:
       - windows
     goarch:
       - amd64
-    ldflags:
-      - -s -w
-      - -X skillguard/cmd.version={{ .Version }}
-    env:
-      - CGO_ENABLED=0
-
-  - id: skillguard-windows-arm64
-    binary: skillguard
-    main: ./main.go
-    goos:
-      - windows
-    goarch:
       - arm64
     ldflags:
       - -s -w
       - -X skillguard/cmd.version={{ .Version }}
     env:
       - CGO_ENABLED=0
+    archives:
+      - id: windows-archive
+        formats:
+          - tar.gz
+          - zip
 
 release:
   draft: false
@@ -112,7 +85,5 @@ brews:
     homepage: "https://github.com/OSSAfrica/skillguard"
     description: "Security scanner for AI skill definitions"
     license: "MIT"
-    goos: darwin
-    goarch:
-      - amd64
-      - arm64
+    ids:
+      - skillguard-darwin


### PR DESCRIPTION
This PR adds the Homebrew tap configuration to enable automatic publication of the SkillGuard formula to a dedicated tap repository on GitHub releases.

### Changes

- Added `brews` section to `.goreleaser.yml` to publish formula to `homebrew-skillguard` repository
- Restructured build configs by grouping by OS (darwin, linux, windows) for better compatibility

### How It Works

1. When code is merged to `main`, the release workflow automatically:
   - Calculates the next version based on commit messages
   - Creates a Git tag
   - Builds binaries for Linux, macOS (Intel + ARM), and Windows
   - Creates a GitHub release
   - Auto-commits the Homebrew formula to `homebrew-skillguard`

2. Users can then install SkillGuard with:
   ```bash
   brew tap OSSAfrica/skillguard
   brew install skillguard
   ```

### Requirements

- [x] Create empty `homebrew-skillguard` repository on GitHub (owner: OSSAfrica)

### Testing

After merge, verify the release workflow runs successfully and the formula appears in the `homebrew-skillguard` repository.