### PR TITLE
feat(release): add Homebrew tap configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,5 +76,3 @@ brews:
     homepage: "https://github.com/OSSAfrica/skillguard"
     description: "Security scanner for AI skill definitions"
     license: "MIT"
-    ids:
-      - skillguard-darwin


### PR DESCRIPTION
This PR adds the Homebrew tap configuration to enable automatic publication of the SkillGuard formula to a dedicated tap repository on GitHub releases.

### Changes

- Added `brews` section to `.goreleaser.yml` to publish formula to `homebrew-skillguard` repository
- Restructured build configs by grouping by OS (darwin, linux, windows)

### How It Works

1. When code is merged to `main`, the release workflow automatically:
   - Calculates the next version based on commit messages
   - Creates a Git tag
   - Builds binaries for Linux, macOS (Intel + ARM), and Windows
   - Creates a GitHub release
   - Auto-commits the Homebrew formula to `homebrew-skillguard`

2. Users can then install SkillGuard with:
   ```bash
   brew tap OSSAfrica/skillguard
   brew install skillguard
   ```

### Requirements

- [x] Create empty `homebrew-skillguard` repository on GitHub (owner: OSSAfrica)

### Testing

After merge, verify the release workflow runs successfully and the formula appears in the `homebrew-skillguard` repository.