### PR TITLE
feat(release): add Homebrew tap configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,8 +24,10 @@ builds:
   - id: darwin-amd64
     binary: skillguard
     main: ./main.go
-    goos: darwin
-    goarch: amd64
+    goos:
+      - darwin
+    goarch:
+      - amd64
     ldflags:
       - -s -w
       - -X skillguard/cmd.version={{ .Version }}
@@ -35,8 +37,10 @@ builds:
   - id: darwin-arm64
     binary: skillguard
     main: ./main.go
-    goos: darwin
-    goarch: arm64
+    goos:
+      - darwin
+    goarch:
+      - arm64
     ldflags:
       - -s -w
       - -X skillguard/cmd.version={{ .Version }}
@@ -46,8 +50,10 @@ builds:
   - id: linux-amd64
     binary: skillguard
     main: ./main.go
-    goos: linux
-    goarch: amd64
+    goos:
+      - linux
+    goarch:
+      - amd64
     ldflags:
       - -s -w
       - -X skillguard/cmd.version={{ .Version }}
@@ -57,8 +63,10 @@ builds:
   - id: linux-arm64
     binary: skillguard
     main: ./main.go
-    goos: linux
-    goarch: arm64
+    goos:
+      - linux
+    goarch:
+      - arm64
     ldflags:
       - -s -w
       - -X skillguard/cmd.version={{ .Version }}
@@ -68,8 +76,10 @@ builds:
   - id: windows-amd64
     binary: skillguard
     main: ./main.go
-    goos: windows
-    goarch: amd64
+    goos:
+      - windows
+    goarch:
+      - amd64
     ldflags:
       - -s -w
       - -X skillguard/cmd.version={{ .Version }}
@@ -79,8 +89,10 @@ builds:
   - id: windows-arm64
     binary: skillguard
     main: ./main.go
-    goos: windows
-    goarch: arm64
+    goos:
+      - windows
+    goarch:
+      - arm64
     ldflags:
       - -s -w
       - -X skillguard/cmd.version={{ .Version }}


### PR DESCRIPTION
This PR adds the Homebrew tap configuration to enable automatic publication of the SkillGuard formula to a dedicated tap repository on GitHub releases.

### Changes

- Added `brews` section to `.goreleaser.yml` to publish formula to `homebrew-skillguard` repository
- Split builds into individual OS/arch combinations for Homebrew compatibility
- Restricted brew to only use darwin builds (amd64 + arm64)
- Fixed goos/goarch to use array format

### How It Works

1. When code is merged to `main`, the release workflow automatically:
   - Calculates the next version based on commit messages
   - Creates a Git tag
   - Builds binaries for Linux, macOS (Intel + ARM), and Windows
   - Creates a GitHub release
   - Auto-commits the Homebrew formula to `homebrew-skillguard`

2. Users can then install SkillGuard with:
   ```bash
   brew tap OSSAfrica/skillguard
   brew install skillguard
   ```

### Requirements

- [x] Create empty `homebrew-skillguard` repository on GitHub (owner: OSSAfrica)

### Testing

After merge, verify the release workflow runs successfully and the formula appears in the `homebrew-skillguard` repository.