### PR TITLE
feat(release): add Homebrew tap configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -102,15 +102,12 @@ builds:
 release:
   draft: false
 
-brews:
+homebrew_casks:
   - repository:
       owner: OSSAfrica
       name: homebrew-skillguard
       token: "{{ .Env.GITHUB_TOKEN }}"
-    directory: Formula
     homepage: "https://github.com/OSSAfrica/skillguard"
     description: "Security scanner for AI skill definitions"
     license: "MIT"
-    ids:
-      - darwin-amd64
-      - darwin-arm64
+    name: skillguard


### PR DESCRIPTION
This PR adds the Homebrew tap configuration to enable automatic publication of the SkillGuard formula to a dedicated tap repository on GitHub releases.

### Changes

- Added `homebrew_casks` section to `.goreleaser.yml` to publish to `homebrew-skillguard` repository
- Migrated from deprecated `brews` to `homebrew_casks`
- Split builds into individual OS/arch combinations for compatibility

### How It Works

1. When code is merged to `main`, the release workflow automatically:
   - Calculates the next version based on commit messages
   - Creates a Git tag
   - Builds binaries for Linux, macOS (Intel + ARM), and Windows
   - Creates a GitHub release
   - Auto-commits the Homebrew cask to `homebrew-skillguard`

2. Users can then install SkillGuard with:
   ```bash
   brew tap OSSAfrica/skillguard
   brew install skillguard
   ```

### Requirements

- [x] Create empty `homebrew-skillguard` repository on GitHub (owner: OSSAfrica)

### Testing

After merge, verify the release workflow runs successfully and the cask appears in the `homebrew-skillguard` repository.