### PR TITLE
fix(cmd): handle SeverityCritical in colors and icons

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -296,6 +296,8 @@ func getScoreColor(score int) *color.Color {
 
 func getSeverityColor(sev model.Severity) *color.Color {
 	switch sev {
+	case model.SeverityCritical:
+		return color.New(color.FgHiRed)
 	case model.SeverityHigh:
 		return color.New(color.FgRed)
 	case model.SeverityMedium:
@@ -307,6 +309,8 @@ func getSeverityColor(sev model.Severity) *color.Color {
 
 func getSeverityIcon(sev model.Severity) string {
 	switch sev {
+	case model.SeverityCritical:
+		return "[CRITICAL]"
 	case model.SeverityHigh:
 		return "[HIGH]"
 	case model.SeverityMedium:


### PR DESCRIPTION
This PR fixes the logic in cmd/scan.go where critical severity findings were not explicitly handled, causing them to default to a "Low" severity label and color.

Changes:

- Added model.SeverityCritical case to getSeverityColor.
- Added model.SeverityCritical case to getSeverityIcon.

Closes #46 