### PR TITLE
feat: add GitHub Action for SkillGuard scanning

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -1,0 +1,58 @@
+name: Action CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'action.yml'
+      - '.github/workflows/action-ci.yml'
+  pull_request:
+    paths:
+      - 'action.yml'
+      - '.github/workflows/action-ci.yml'
+
+jobs:
+  test-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test action with default inputs
+        id: default
+        uses: ./
+        with:
+          path: '.'
+          threshold: 70
+        continue-on-error: true
+
+      - name: Test action with JSON output
+        id: with-output
+        uses: ./
+        with:
+          path: '.'
+          threshold: 70
+          output: 'test-report.json'
+          verbose: true
+        continue-on-error: true
+
+      - name: Verify outputs are set
+        run: |
+          echo "Default run result: ${{ steps.default.outputs.result }}"
+          echo "Output run result:  ${{ steps.with-output.outputs.result }}"
+          echo "Total skills:       ${{ steps.with-output.outputs.total_skills }}"
+          echo "Passed:             ${{ steps.with-output.outputs.passed_count }}"
+          echo "Failed:             ${{ steps.with-output.outputs.failed_count }}"
+          echo "Report path:        ${{ steps.with-output.outputs.report_path }}"
+
+          if [[ -z "${{ steps.with-output.outputs.result }}" ]]; then
+            echo "ERROR: result output was not set"
+            exit 1
+          fi
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: action-test-report
+          path: test-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -10,12 +10,14 @@ on:
     paths:
       - 'action.yml'
       - '.github/workflows/action-ci.yml'
+permissions:
+  contents: read
 
 jobs:
   test-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Test action with default inputs
         id: default
@@ -51,7 +53,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: action-test-report
           path: test-report.json

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Test action with default inputs
         id: default

--- a/action.yml
+++ b/action.yml
@@ -71,14 +71,14 @@ runs:
         if [[ -n "${INPUT_OUTPUT}" ]]; then
           docker run --rm \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "${TEMP_DIR}:/tmp_output" \
+            -v "${TEMP_DIR}:/tmp" \
             -w /workspace \
             --user root \
             "${IMAGE}" \
             scan \
             --path "${INPUT_PATH}" \
             --threshold "${INPUT_THRESHOLD}" \
-            --output "/tmp_output/skillguard-report.json" \
+            --output "/tmp/skillguard-report.json" \
             $( [[ "${INPUT_QUIET}" == "true" ]] && echo "--quiet" ) \
             $( [[ "${INPUT_VERBOSE}" == "true" ]] && echo "--verbose" )
         else
@@ -96,8 +96,8 @@ runs:
         set -e
 
         # Copy the report from temp directory to workspace if output was specified
-        if [[ -n "${INPUT_OUTPUT}" && -f "${CONTAINER_OUTPUT}" ]]; then
-          cp "${CONTAINER_OUTPUT}" "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
+        if [[ -n "${INPUT_OUTPUT}" && -f "${TEMP_DIR}/skillguard-report.json" ]]; then
+          cp "${TEMP_DIR}/skillguard-report.json" "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
           REPORT="${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
           TOTAL=$(jq '.total_skills' "${REPORT}")
           PASSED=$(jq '.passed' "${REPORT}")

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,117 @@
+name: 'SkillGuard'
+description: 'Security scanner for AI agent skill definitions — detects vulnerabilities, dangerous permissions, and supply chain risks'
+author: 'OSSAfrica'
+
+branding:
+  icon: 'shield'
+  color: 'blue'
+
+inputs:
+  path:
+    description: 'Path to scan (file, directory, or comma-separated paths)'
+    required: false
+    default: '.'
+  threshold:
+    description: 'Minimum score to pass (0-100)'
+    required: false
+    default: '70'
+  output:
+    description: 'Output JSON report to file'
+    required: false
+    default: ''
+  quiet:
+    description: 'Minimal output - just pass/fail'
+    required: false
+    default: 'false'
+  verbose:
+    description: 'Show all findings and detailed breakdown'
+    required: false
+    default: 'false'
+
+outputs:
+  result:
+    description: 'Overall scan result: passed or failed'
+    value: ${{ steps.scan.outputs.result }}
+  total_skills:
+    description: 'Number of skills scanned'
+    value: ${{ steps.scan.outputs.total_skills }}
+  passed_count:
+    description: 'Number of skills that passed'
+    value: ${{ steps.scan.outputs.passed_count }}
+  failed_count:
+    description: 'Number of skills that failed'
+    value: ${{ steps.scan.outputs.failed_count }}
+  report_path:
+    description: 'Path to the JSON report file (if output was specified)'
+    value: ${{ steps.scan.outputs.report_path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run SkillGuard scan
+      id: scan
+      shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_THRESHOLD: ${{ inputs.threshold }}
+        INPUT_OUTPUT: ${{ inputs.output }}
+        INPUT_QUIET: ${{ inputs.quiet }}
+        INPUT_VERBOSE: ${{ inputs.verbose }}
+      run: |
+        # Build the skillguard command arguments
+        ARGS="scan --path \"${INPUT_PATH}\" --threshold ${INPUT_THRESHOLD}"
+
+        if [[ -n "${INPUT_OUTPUT}" ]]; then
+          ARGS="${ARGS} --output \"${INPUT_OUTPUT}\""
+        fi
+
+        if [[ "${INPUT_QUIET}" == "true" ]]; then
+          ARGS="${ARGS} --quiet"
+        fi
+
+        if [[ "${INPUT_VERBOSE}" == "true" ]]; then
+          ARGS="${ARGS} --verbose"
+        fi
+
+        # Pull and run the SkillGuard Docker image
+        IMAGE="ghcr.io/ossafrica/skillguard:latest"
+        docker pull "${IMAGE}"
+
+        set +e
+        docker run --rm \
+          -v "${GITHUB_WORKSPACE}:/workspace" \
+          -w /workspace \
+          "${IMAGE}" \
+          scan \
+          --path "${INPUT_PATH}" \
+          --threshold "${INPUT_THRESHOLD}" \
+          $( [[ -n "${INPUT_OUTPUT}" ]] && echo "--output ${INPUT_OUTPUT}" ) \
+          $( [[ "${INPUT_QUIET}" == "true" ]] && echo "--quiet" ) \
+          $( [[ "${INPUT_VERBOSE}" == "true" ]] && echo "--verbose" )
+        EXIT_CODE=$?
+        set -e
+
+        # Parse outputs from the JSON report if available
+        if [[ -n "${INPUT_OUTPUT}" && -f "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}" ]]; then
+          REPORT="${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
+          TOTAL=$(jq '.total_skills' "${REPORT}")
+          PASSED=$(jq '.passed' "${REPORT}")
+          FAILED=$(jq '.failed' "${REPORT}")
+          echo "total_skills=${TOTAL}" >> "${GITHUB_OUTPUT}"
+          echo "passed_count=${PASSED}" >> "${GITHUB_OUTPUT}"
+          echo "failed_count=${FAILED}" >> "${GITHUB_OUTPUT}"
+          echo "report_path=${INPUT_OUTPUT}" >> "${GITHUB_OUTPUT}"
+        else
+          echo "total_skills=" >> "${GITHUB_OUTPUT}"
+          echo "passed_count=" >> "${GITHUB_OUTPUT}"
+          echo "failed_count=" >> "${GITHUB_OUTPUT}"
+          echo "report_path=" >> "${GITHUB_OUTPUT}"
+        fi
+
+        if [[ ${EXIT_CODE} -eq 0 ]]; then
+          echo "result=passed" >> "${GITHUB_OUTPUT}"
+        else
+          echo "result=failed" >> "${GITHUB_OUTPUT}"
+        fi
+
+        exit ${EXIT_CODE}

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,7 @@ runs:
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -v "${TEMP_DIR}:/tmp_output" \
             -w /workspace \
+            --user root \
             "${IMAGE}" \
             scan \
             --path "${INPUT_PATH}" \

--- a/action.yml
+++ b/action.yml
@@ -58,41 +58,45 @@ runs:
         INPUT_QUIET: ${{ inputs.quiet }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
       run: |
-        # Build the skillguard command arguments
-        ARGS="scan --path \"${INPUT_PATH}\" --threshold ${INPUT_THRESHOLD}"
-
-        if [[ -n "${INPUT_OUTPUT}" ]]; then
-          ARGS="${ARGS} --output \"${INPUT_OUTPUT}\""
-        fi
-
-        if [[ "${INPUT_QUIET}" == "true" ]]; then
-          ARGS="${ARGS} --quiet"
-        fi
-
-        if [[ "${INPUT_VERBOSE}" == "true" ]]; then
-          ARGS="${ARGS} --verbose"
-        fi
-
-        # Pull and run the SkillGuard Docker image
+        # Pull the SkillGuard Docker image
         IMAGE="ghcr.io/ossafrica/skillguard:latest"
         docker pull "${IMAGE}"
 
+        # Create a temporary directory for container output
+        TEMP_DIR=$(mktemp -d)
+        CONTAINER_OUTPUT="${TEMP_DIR}/skillguard-report.json"
+
+        # Run the container with output to temp directory
         set +e
-        docker run --rm \
-          -v "${GITHUB_WORKSPACE}:/workspace" \
-          -w /workspace \
-          "${IMAGE}" \
-          scan \
-          --path "${INPUT_PATH}" \
-          --threshold "${INPUT_THRESHOLD}" \
-          $( [[ -n "${INPUT_OUTPUT}" ]] && echo "--output ${INPUT_OUTPUT}" ) \
-          $( [[ "${INPUT_QUIET}" == "true" ]] && echo "--quiet" ) \
-          $( [[ "${INPUT_VERBOSE}" == "true" ]] && echo "--verbose" )
+        if [[ -n "${INPUT_OUTPUT}" ]]; then
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -v "${TEMP_DIR}:/tmp_output" \
+            -w /workspace \
+            "${IMAGE}" \
+            scan \
+            --path "${INPUT_PATH}" \
+            --threshold "${INPUT_THRESHOLD}" \
+            --output "/tmp_output/skillguard-report.json" \
+            $( [[ "${INPUT_QUIET}" == "true" ]] && echo "--quiet" ) \
+            $( [[ "${INPUT_VERBOSE}" == "true" ]] && echo "--verbose" )
+        else
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -w /workspace \
+            "${IMAGE}" \
+            scan \
+            --path "${INPUT_PATH}" \
+            --threshold "${INPUT_THRESHOLD}" \
+            $( [[ "${INPUT_QUIET}" == "true" ]] && echo "--quiet" ) \
+            $( [[ "${INPUT_VERBOSE}" == "true" ]] && echo "--verbose" )
+        fi
         EXIT_CODE=$?
         set -e
 
-        # Parse outputs from the JSON report if available
-        if [[ -n "${INPUT_OUTPUT}" && -f "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}" ]]; then
+        # Copy the report from temp directory to workspace if output was specified
+        if [[ -n "${INPUT_OUTPUT}" && -f "${CONTAINER_OUTPUT}" ]]; then
+          cp "${CONTAINER_OUTPUT}" "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
           REPORT="${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
           TOTAL=$(jq '.total_skills' "${REPORT}")
           PASSED=$(jq '.passed' "${REPORT}")
@@ -107,6 +111,9 @@ runs:
           echo "failed_count=" >> "${GITHUB_OUTPUT}"
           echo "report_path=" >> "${GITHUB_OUTPUT}"
         fi
+
+        # Clean up temp directory
+        rm -rf "${TEMP_DIR}"
 
         if [[ ${EXIT_CODE} -eq 0 ]]; then
           echo "result=passed" >> "${GITHUB_OUTPUT}"

--- a/action.yml
+++ b/action.yml
@@ -93,31 +93,39 @@ runs:
             $( [[ "${INPUT_VERBOSE}" == "true" ]] && echo "--verbose" )
         fi
         EXIT_CODE=$?
-        set -e
 
-        # Copy the report from temp directory to workspace if output was specified
-        if [[ -n "${INPUT_OUTPUT}" && -f "${TEMP_DIR}/skillguard-report.json" ]]; then
-          chmod 644 "${TEMP_DIR}/skillguard-report.json"
-          cp "${TEMP_DIR}/skillguard-report.json" "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
-          REPORT="${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
-          TOTAL=$(jq '.total_skills' "${REPORT}")
-          PASSED=$(jq '.passed' "${REPORT}")
-          FAILED=$(jq '.failed' "${REPORT}")
-          echo "total_skills=${TOTAL}" >> "${GITHUB_OUTPUT}"
-          echo "passed_count=${PASSED}" >> "${GITHUB_OUTPUT}"
-          echo "failed_count=${FAILED}" >> "${GITHUB_OUTPUT}"
-          echo "report_path=${INPUT_OUTPUT}" >> "${GITHUB_OUTPUT}"
-        else
-          echo "total_skills=" >> "${GITHUB_OUTPUT}"
-          echo "passed_count=" >> "${GITHUB_OUTPUT}"
-          echo "failed_count=" >> "${GITHUB_OUTPUT}"
-          echo "report_path=" >> "${GITHUB_OUTPUT}"
-        fi
-
+        # Set output based on exit code
         if [[ ${EXIT_CODE} -eq 0 ]]; then
           echo "result=passed" >> "${GITHUB_OUTPUT}"
         else
           echo "result=failed" >> "${GITHUB_OUTPUT}"
         fi
 
+        # Copy the report from temp directory to workspace if output was specified
+        if [[ -n "${INPUT_OUTPUT}" && -f "${TEMP_DIR}/skillguard-report.json" ]]; then
+          # Ensure destination directory exists
+          mkdir -p "$(dirname "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}")"
+        
+          chmod 644 "${TEMP_DIR}/skillguard-report.json"
+          cp "${TEMP_DIR}/skillguard-report.json" "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
+          REPORT="${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
+          # Check for nulls
+          TOTAL=$(jq -r '.total_skills // 0' "${REPORT}" || echo "0")
+          PASSED=$(jq -r '.passed // 0' "${REPORT}" || echo "0")
+          FAILED=$(jq -r '.failed // 0' "${REPORT}" || echo "0")
+        
+          echo "total_skills=${TOTAL}" >> "${GITHUB_OUTPUT}"
+          echo "passed_count=${PASSED}" >> "${GITHUB_OUTPUT}"
+          echo "failed_count=${FAILED}" >> "${GITHUB_OUTPUT}"
+          echo "report_path=${INPUT_OUTPUT}" >> "${GITHUB_OUTPUT}"
+        else
+          # Set defaults
+          echo "total_skills=0" >> "${GITHUB_OUTPUT}"
+          echo "passed_count=0" >> "${GITHUB_OUTPUT}"
+          echo "failed_count=0" >> "${GITHUB_OUTPUT}"
+          echo "report_path=" >> "${GITHUB_OUTPUT}"
+        fi
+        
+        # Clean up
+        rm -rf "${TEMP_DIR}"
         exit ${EXIT_CODE}

--- a/action.yml
+++ b/action.yml
@@ -97,6 +97,7 @@ runs:
 
         # Copy the report from temp directory to workspace if output was specified
         if [[ -n "${INPUT_OUTPUT}" && -f "${TEMP_DIR}/skillguard-report.json" ]]; then
+          chmod 644 "${TEMP_DIR}/skillguard-report.json"
           cp "${TEMP_DIR}/skillguard-report.json" "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
           REPORT="${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
           TOTAL=$(jq '.total_skills' "${REPORT}")
@@ -112,9 +113,6 @@ runs:
           echo "failed_count=" >> "${GITHUB_OUTPUT}"
           echo "report_path=" >> "${GITHUB_OUTPUT}"
         fi
-
-        # Clean up temp directory
-        rm -rf "${TEMP_DIR}"
 
         if [[ ${EXIT_CODE} -eq 0 ]]; then
           echo "result=passed" >> "${GITHUB_OUTPUT}"

--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,7 @@ runs:
           # Ensure destination directory exists
           mkdir -p "$(dirname "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}")"
         
-          chmod 644 "${TEMP_DIR}/skillguard-report.json"
+          sudo chmod 644 "${TEMP_DIR}/skillguard-report.json"
           cp "${TEMP_DIR}/skillguard-report.json" "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
           REPORT="${GITHUB_WORKSPACE}/${INPUT_OUTPUT}"
           # Check for nulls

--- a/examples/github-actions/skill-scan-pr.yml
+++ b/examples/github-actions/skill-scan-pr.yml
@@ -1,0 +1,27 @@
+name: Scan AI Skills (PR)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan AI Skills
+        uses: ossafrica/skillguard-action@v1
+        with:
+          path: './skills'
+          threshold: 70
+          output: 'skillguard-report.json'
+
+      - name: Upload scan report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skillguard-report
+          path: skillguard-report.json

--- a/examples/github-actions/skill-scan-scheduled.yml
+++ b/examples/github-actions/skill-scan-scheduled.yml
@@ -1,0 +1,37 @@
+name: Scheduled Skill Scan
+
+on:
+  schedule:
+    # Runs every day at 08:00 UTC
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan AI Skills
+        id: skillguard
+        uses: ossafrica/skillguard-action@v1
+        with:
+          path: '.'
+          threshold: 80
+          output: 'skillguard-report.json'
+          verbose: true
+
+      - name: Print scan summary
+        if: always()
+        run: |
+          echo "Result:       ${{ steps.skillguard.outputs.result }}"
+          echo "Total skills: ${{ steps.skillguard.outputs.total_skills }}"
+          echo "Passed:       ${{ steps.skillguard.outputs.passed_count }}"
+          echo "Failed:       ${{ steps.skillguard.outputs.failed_count }}"
+
+      - name: Upload scan report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skillguard-report-${{ github.run_id }}
+          path: skillguard-report.json

--- a/examples/github-actions/skill-scan.yml
+++ b/examples/github-actions/skill-scan.yml
@@ -3,7 +3,7 @@
 # Copy this file to your skill repository at:
 #   .github/workflows/skillguard.yml
 #
-# Then customize the 'path' argument below to point to your skills directory.
+# Then customize the 'path' input below to point to your skills directory.
 
 name: SkillGuard Security Scan
 
@@ -23,10 +23,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run SkillGuard scan
-        uses: docker://OSSAfrica/skillguard:latest
+      - name: Scan AI Skills
+        id: skillguard
+        uses: ossafrica/skillguard-action@v1
         with:
-          args: scan --path ./skills --threshold 70 --output skillguard-report.json
+          path: './skills'
+          threshold: 70
+          output: 'skillguard-report.json'
 
       - name: Upload report
         uses: actions/upload-artifact@v4
@@ -34,13 +37,3 @@ jobs:
         with:
           name: skillguard-report
           path: skillguard-report.json
-
-      - name: Fail if security issues found
-        run: |
-          if [ -f skillguard-report.json ]; then
-            FAILED=$(grep -o '"failed":[0-9]*' skillguard-report.json | grep -o '[0-9]*')
-            if [ "$FAILED" -gt "0" ]; then
-              echo "Security scan found $FAILED skill(s) failing security checks"
-              exit 1
-            fi
-          fi


### PR DESCRIPTION
- Add action.yml with inputs: path, threshold, output, quiet, verbose
- Add outputs: result, total_skills, passed_count, failed_count, report_path
- Update example workflows to use the new action
- Add CI workflow to test the action itself

Closes #49 