### PR TITLE
Fix action name in example and inject release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ env.REPO }}:latest
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ needs.versioning.outputs.version }}
 
   sign:
     needs: [ versioning, docker ]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ builds:
       - amd64
     ldflags:
       - -s -w
-      - -X skillguard/cmd.version={{ .Version }}
+      - -X skillguard/cmd.Version={{ .Version }}
     env:
       - CGO_ENABLED=0
 
@@ -43,7 +43,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X skillguard/cmd.version={{ .Version }}
+      - -X skillguard/cmd.Version={{ .Version }}
     env:
       - CGO_ENABLED=0
 
@@ -56,7 +56,7 @@ builds:
       - amd64
     ldflags:
       - -s -w
-      - -X skillguard/cmd.version={{ .Version }}
+      - -X skillguard/cmd.Version={{ .Version }}
     env:
       - CGO_ENABLED=0
 
@@ -69,7 +69,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X skillguard/cmd.version={{ .Version }}
+      - -X skillguard/cmd.Version={{ .Version }}
     env:
       - CGO_ENABLED=0
 
@@ -82,7 +82,7 @@ builds:
       - amd64
     ldflags:
       - -s -w
-      - -X skillguard/cmd.version={{ .Version }}
+      - -X skillguard/cmd.Version={{ .Version }}
     env:
       - CGO_ENABLED=0
 
@@ -95,7 +95,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X skillguard/cmd.version={{ .Version }}
+      - -X skillguard/cmd.Version={{ .Version }}
     env:
       - CGO_ENABLED=0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM cgr.dev/chainguard/go@sha256:cdd198f79e8bd05933cd1bf7113d404065edca90e45859bed16b41c57aeb853b AS builder
 
+ARG VERSION=dev
+
 WORKDIR /app
 
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o skillguard .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X skillguard/cmd.Version=${VERSION}" -o skillguard .
 
 FROM cgr.dev/chainguard/static@sha256:d6d54da1c5bf5d9cecb231786adca86934607763067c8d7d9d22057abe6d5dbc
 

--- a/examples/github-actions/skill-scan-pr.yml
+++ b/examples/github-actions/skill-scan-pr.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Scan AI Skills
-        uses: ossafrica/skillguard-action@v1
+        uses: ossafrica/skillguard@v1
         with:
           path: './skills'
           threshold: 70

--- a/examples/github-actions/skill-scan-scheduled.yml
+++ b/examples/github-actions/skill-scan-scheduled.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Scan AI Skills
         id: skillguard
-        uses: ossafrica/skillguard-action@v1
+        uses: ossafrica/skillguard@v1
         with:
           path: '.'
           threshold: 80

--- a/examples/github-actions/skill-scan.yml
+++ b/examples/github-actions/skill-scan.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Scan AI Skills
         id: skillguard
-        uses: ossafrica/skillguard-action@v1
+        uses: ossafrica/skillguard@v1
         with:
           path: './skills'
           threshold: 70


### PR DESCRIPTION
- Fix action name
- Update .goreleaser.yml to inject version into all build targets
- Update Dockerfile to accept VERSION build arg and use it in go build
- Pass version from release workflow to Docker build as build arg

Closes #68 